### PR TITLE
Set recipient email to order email if nil

### DIFF
--- a/app/models/concerns/spree/gift_cards/order_concerns.rb
+++ b/app/models/concerns/spree/gift_cards/order_concerns.rb
@@ -35,6 +35,9 @@ module Spree
 
           inventory_units = self.inventory_units
           gift_cards.each_with_index do |gift_card, index|
+            unless gift_card.recipient_email.present?
+              gift_card.recipient_email = email
+            end
             gift_card.make_redeemable!(purchaser: user, inventory_unit: inventory_units[index])
           end
         end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -15,6 +15,17 @@ describe Spree::Order do
         expect(gift_card.reload.redeemable).to be true
         expect(gift_card.reload.redemption_code).to be_present
       end
+
+      context 'when the gift card has no recipient info' do
+        let(:gift_card) {
+          create(:virtual_gift_card, recipient_email: nil, recipient_name: nil)
+        }
+
+        it 'sets the recipient email to the order email' do
+          subject
+          expect(gift_card.reload.recipient_email).to eq(order.email)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
When a recipient email isn't supplied, someone needs to receive the gift
card so send it to the person who placed the order.