### PR TITLE
Let line items decorator play nice with reloading

### DIFF
--- a/app/controllers/spree/api/line_items_controller_decorator.rb
+++ b/app/controllers/spree/api/line_items_controller_decorator.rb
@@ -1,19 +1,14 @@
 # frozen_string_literal: true
 
-module LineItemDecorator
-  extend ActiveSupport::Concern
-
-  included do
-    prepend(InstanceMethods)
+module LineItemsControllerDecorator
+  def permitted_line_item_attributes
+    super + [
+      gift_card_details: [
+        :recipient_name, :recipient_email, :gift_message, :purchaser_name,
+        :send_email_at
+      ]
+    ]
   end
 
-  module InstanceMethods
-    private
-
-    def permitted_line_item_attributes
-      super + [gift_card_details: [:recipient_name, :recipient_email, :gift_message, :purchaser_name, :send_email_at]]
-    end
-  end
+  Spree::Api::LineItemsController.prepend(self)
 end
-
-Spree::Api::LineItemsController.include LineItemDecorator


### PR DESCRIPTION
AS::Concern and decorators don't work very well together and raises `Cannot define multiple 'included' blocks for a Concern`.

This PR changes the decorator to use prepend instead.

Using `prepend` vs. `include` should be irrelevant in this case, as the original method also uses `super`.

<img width="1792" alt="Screenshot 2019-06-19 at 19 34 10" src="https://user-images.githubusercontent.com/1051/59787427-b25c8380-92c9-11e9-98d8-a8657fb611ff.png">


