### PR TITLE
Check users by email case-insensitive

### DIFF
--- a/lib/solidus_virtual_gift_card/user_generator.rb
+++ b/lib/solidus_virtual_gift_card/user_generator.rb
@@ -20,16 +20,15 @@ module SolidusVirtualGiftCard
       existing_user || create_stub_user
     end
 
-    def existing_user_attrs
-      { email: order.email }.tap do |u_attrs|
-        if Spree.user_class.new.respond_to?(:team)
-          u_attrs[:team] = order.team
-        end
-      end
-    end
-
     def existing_user
-      Spree.user_class.where(existing_user_attrs).first
+      base = Spree.user_class.where("LOWER(email)=?", order.email.downcase)
+      if Spree.user_class.new.respond_to?(:team)
+        base = base.where(team_id: order.team.id)
+      else
+        base
+      end
+
+      base.first
     end
 
     def create_stub_user

--- a/spec/lib/solidus_virtual_gift_card/user_generator_spec.rb
+++ b/spec/lib/solidus_virtual_gift_card/user_generator_spec.rb
@@ -4,12 +4,27 @@ module SolidusVirtualGiftCard
   RSpec.describe UserGenerator, type: :model do
     let(:generator) { described_class.new(order) }
     let!(:order) { create(:completed_order_with_totals) }
+    let(:user) { order.user }
 
     describe '#user' do
       subject { generator.user }
 
       context 'when a user exists' do
         let(:user) { order.user }
+
+        it 'does not create a new user' do
+          expect { subject }.to_not change { Spree.user_class.count }
+        end
+
+        it 'returns the existing user' do
+          expect(subject).to eq(user)
+        end
+      end
+
+      context 'when a user exists with a case-distinct email' do
+        before do
+          order.update_attributes!(email: order.email.upcase)
+        end
 
         it 'does not create a new user' do
           expect { subject }.to_not change { Spree.user_class.count }


### PR DESCRIPTION
When we want to generate a user for an order, we need to check for an
existing user by email in a case-insensitive manner.

Rollbar error source:
https://rollbar.com/enginecommerce/engine_storefront/items/614/